### PR TITLE
update lts so that we don't need wreq dep. explicitly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Guidelines
+
+## Contributor Agreement
+A pull-request will only be considered for merging into the upstream codebase after you have signed our [contributor agreement] (https://github.com/nstack/nstack/blob/master/Contributor%20Agreement.md), assigning us the rights to the contributed code and granting you a license to use it in return. If you submit a pull request, you will be prompted to review and sign the agreement with one click (we use [CLA assistant] (https://cla-assistant.io/)).

--- a/Contributor_Agreement.md
+++ b/Contributor_Agreement.md
@@ -1,0 +1,39 @@
+# NStack contributor agreement
+
+This NStack Agreement (this **"Agreement"**) applies to any Contribution you make to any Work. 
+
+This is a binding legal agreement on you and any organization you represent. If you are signing this Agreement on behalf of your employer or other organization, you represent and warrant that you have the authority to agree to this Agreement on behalf of the organization. 
+
+## 1. Definitions
+
+**"Contribution"** means any original work, including any modification of or addition to an existing work, that you submit to NStack in any manner for inclusion in any Work. 
+
+**"NStack", "we"** and **"use"** means StackHut Ltd. 
+
+**"Work"** means any project, work or materials owned or managed by StackHut Ltd. 
+
+**"You"** and **"your"** means you and any organization on whose behalf you are entering this Agreement. 
+
+## 2. Copyright Assignment, License and Waiver
+
+**(a) Assignment.** By submitting a Contribution, you assign to NStack all right, title and interest in any copright you have in the Contribution, and you waive any rights, including any moral rights, database rights, etc., that may affect your ownership of the copyright in the Contribution. 
+
+**(b) License to NStack.** If your assignment in Section 2(a) is ineffective for any reason, you grant to us and to any recipient of any Work distributed by use, a perpetual, worldwide, transferable, non-exclusive, no-charge, royalty-free, irrevocable, and sublicensable licence to use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Contributions and any derivative work created based on a Contribution. If your license grant is ineffective for any reason, you irrevocably waive and covenant to not assert any claim you may have against us, our successors in interest, and any of our direct or indirect licensees and customers, arising out of our, our successors in interest's, or any of our direct or indirect licensees' or customers' use, reproduction, preparation of derivative works, public display, public performance, sublicense, and distribution of a Contribution. You also agree that we may publicly use your name and the name of any organization on whose behalf you're entering into this Agreement in connection with publicizing the Work.
+
+**(c) License to you.** We grant to you a perpetual, worldwide, transferable, non-exclusive, no-charge, royalty-free, irrevocable, and sublicensable license to use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute a Contribution and any derivative works you create based on a Contribution. 
+
+## 3. Patent License
+You grant to us and to any recipient of any Work distributed by us, a perpetual, worldwide, transferable, non-exclusive, no-charge, royalty-free, irrevocable, and sublicensable patent license to make, have made, use, sell, offer to sell, import, and otherwise transfer the Contribution in whole or in part, along or included in any Work under any patent you own, or license from a third party, that is necessarily infringed by the Contribution or by combination of the Contribution with any Work. 
+
+## 4. Your Representation and Warranties. 
+By submitting a Contribution, you represent and warrant that: (a) each Contribution you submit is an original work and you can legally grant the rights set out in this Agreement; (b) the Contribution does not, and any exercise of the rights granted by you will not, infringe any third party's intellectual property or other right; and (c) you are not aware of any claims, suits, or actions pertaining to the Contribution. You will notify us immediately if you become aware or have reason to believe that any of your representations and warranties is or becomes inaccurate. 
+
+## 5. Intellectual Property
+Except for the assignment and licenses set forth in this Agreement, this Agreement does not transfer any right, title or interest in any intellectual property right of either party to the other. If you choose to provide us with suggestions, ideas for improvement, recommendations or other feedback, on any Work we may use your feedback without any restriction or payment. 
+
+## Miscellaneous
+English law governs this Agreement, excluding any applicable conflict of laws rules or principles, and the parties agree to the exclusive jurisdiction of the courts in England, UK. This Agreement does not create a partnership, agency relationship, or joint venture between the parties. We may assign this Agreement without notice or restriction. If any provision of this Agreement is unenforcable, that provision will be modified to render it enforceable to the extent possible to effect the parties' intention and the remaining provisions will not be affected. The parties may amend this Agreement only in a written amendment signed by both parties. This Agreement comprises the parties' entire agreement relating to the subject matter of this Agreement. 
+
+**Agreed and accepted on my behalf and on behalf of my organization**
+
+Our contributor agreement is based on the [mongoDB contributor agreement](https://www.mongodb.com/legal/contributor-agreement).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2017 StackHut Ltd.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ See https://github.com/nstack/nstack-examples for a range of examples, which you
 * [demos](https://github.com/nstack/nstack-examples/tree/master/demos) - Basic examples that demonstrate creating methods and composing them together into workflows
 * [nstack](https://github.com/nstack/nstack-examples/tree/master/nstack) - A selection of NStack utility modules, including methods for uploading to S3 and processing images
 * [iris](https://github.com/nstack/nstack-examples/tree/master/iris) - A Python-based classifier using `scikit-leaarn` that showcases building more complex modules with system dependencies and in-built data-sets
-* [movies](https://github.com/nstack/nstack-examples/tree/master/movies) - A complex worfklow composed from multiple individual services that processes movies data from the IMDB database -- demonstrating composition, filtering, service configuration, and partial workflow reuse
+* [movies](https://github.com/nstack/nstack-examples/tree/master/movies) - A complex workflow composed from multiple individual services that processes movies data from the IMDB database, demonstrating composition, filtering, service configuration, and partial workflow reuse
 
 ## What do people use NStack for?
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ See https://github.com/nstack/nstack-examples for a range of examples, which you
 * [iris](https://github.com/nstack/nstack-examples/tree/master/iris) - A Python-based classifier using `scikit-leaarn` that showcases building more complex modules with system dependencies and in-built data-sets
 * [movies](https://github.com/nstack/nstack-examples/tree/master/movies) - A complex workflow composed from multiple individual services that processes movies data from the IMDB database, demonstrating composition, filtering, service configuration, and partial workflow reuse
 
+
+## License and Contributing
+
+### License
+
+The NStack CLI is open-source and licensed under the [BSD3 license](https://opensource.org/licenses/BSD-3-Clause). 
+
+The NStack Server is provided free-of-charge for personal, hobbyist, non-commercial, and evaluation use. Unfortunately it is currently closed-source, however we intend to open it up over time.
+
+### Contributing
+
+This repo is currently a mirror of our internal work, as development happens fairly rapidly. However we welcome and encourage both Issues and PRs (unfortunately PRs will require a CLA - we're working on adding one as soon as possible).
+
+We're also looking into removing our mirror and working directly on this public repo if possible.
+
 ## What do people use NStack for?
 
 ### Productionising models

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ The NStack Server is provided free-of-charge for personal, hobbyist, non-commerc
 
 ### Contributing
 
-This repo is currently a mirror of our internal work, as development happens fairly rapidly. However we welcome and encourage both Issues and PRs (unfortunately PRs will require a CLA - we're working on adding one as soon as possible).
+This repo is currently a mirror of our internal work, as development happens fairly rapidly. 
+However we welcome and encourage both Issues and PRs (PRs will require a CLA - as described in [CONTRIBUTING.md](https://github.com/nstack/nstack/blob/master/CONTRIBUTING.md)).
 
 We're also looking into removing our mirror and working directly on this public repo if possible.
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ See https://github.com/nstack/nstack-examples for a range of examples, which you
 
 The NStack CLI is open-source and licensed under the [BSD3 license](https://opensource.org/licenses/BSD-3-Clause). 
 
-The NStack Server is provided free-of-charge for personal, hobbyist, non-commercial, and evaluation use. Unfortunately it is currently closed-source, however we intend to open it up over time.
+The NStack Server is provided free-of-charge for personal, hobbyist, non-commercial, and evaluation use. It is currently closed-source, however we'd like to open more of it up over time.
 
 ### Contributing
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,5 +13,5 @@ extra-deps:
 - mustache-2.1.2
 - tree-view-0.5
 compiler: ghc-8.0.2
-resolver: lts-8.4
+resolver: lts-8.9
 


### PR DESCRIPTION
it doesn't build without explicit wreq dep. with 8.4 lts, so i upgraded it to latest. it still builds, so may as well?